### PR TITLE
Add Agenta as LLM observability alternative

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,7 +425,7 @@ In addition to traditional security problems associated with software, LLMs have
 
 * **Prompt hacking**: Different techniques related to prompt engineering, including prompt injection (additional instruction to hijack the model's answer), data/prompt leaking (retrieve its original data/prompt), and jailbreaking (craft prompts to bypass safety features).
 * **Backdoors**: Attack vectors can target the training data itself, by poisoning the training data (e.g., with false information) or creating backdoors (secret triggers to change the model's behavior during inference).
-* **Defensive measures**: The best way to protect your LLM applications is to test them against these vulnerabilities (e.g., using red teaming and checks like [garak](https://github.com/leondz/garak/)) and observe them in production (with a framework like [langfuse](https://github.com/langfuse/langfuse)).
+* **Defensive measures**: The best way to protect your LLM applications is to test them against these vulnerabilities (e.g., using red teaming and checks like [garak](https://github.com/leondz/garak/)) and observe them in production (with a framework like [langfuse](https://github.com/langfuse/langfuse) or [agenta](https://github.com/agenta-ai/agenta)).
 
 📚 **References**:
 * [OWASP LLM Top 10](https://owasp.org/www-project-top-10-for-large-language-model-applications/) by HEGO Wiki: List of the 10 most critical vulnerabilities seen in LLM applications.


### PR DESCRIPTION
Hi! 👋

I'd like to suggest adding [Agenta](https://github.com/agenta-ai/agenta) as an alternative to Langfuse for LLM observability and monitoring in the defensive measures section.

## What is Agenta?

Agenta is an **open-source LLMOps platform** that provides:
- **LLM Observability & Monitoring**: Track and debug LLM applications in production
- **Prompt Management**: Version control and collaborative prompt engineering  
- **LLM Evaluation**: Both automated and human-in-the-loop evaluation workflows

## Why add it?

- **Open-source alternative**: Like Langfuse, it's fully open-source and self-hostable
- **Production monitoring**: Specifically designed for observing LLM applications in production (fits perfectly with the defensive measures context)
- **Established project**: MIT licensed, 1.2k+ stars, actively maintained since April 2023

## Change Made

I've added Agenta alongside Langfuse in line 428:

```markdown
observe them in production (with a framework like [langfuse](https://github.com/langfuse/langfuse) or [agenta](https://github.com/agenta-ai/agenta))
```

This provides learners with multiple options for LLM observability frameworks when implementing defensive measures for their applications.

Thanks for considering this addition! 🙏